### PR TITLE
#168360951 Mentor can decline a session request

### DIFF
--- a/server/config/queries.js
+++ b/server/config/queries.js
@@ -3,6 +3,7 @@ const query = [
     create: `INSERT INTO users(firstname,lastname,email,password,address,bio,occupation,expertise) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`,
     isUser: `SELECT * FROM users WHERE id=$1`,
     isExist: `SELECT * FROM users WHERE email=$1`,
+    isMentorEmail: `SELECT * FROM users WHERE ismentee=false AND isadmin=false AND email=$1`,
     isAdmin: `SELECT * FROM users WHERE isadmin=true AND ismentee=false`,
     changeToMentor: `UPDATE users SET ismentee=false WHERE id= $1 RETURNING *`,
     getOne: `SELECT firstname, lastname, email, address, bio, occupation, expertise FROM users WHERE ismentee=false AND isadmin=false AND id = $1`,

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -36,13 +36,12 @@ class SessionController {
   }
 
   static declineMentorship(req, res) {
-    const foundSession = sessions.find((sessionObject) => sessionObject.sessionId == req.params.id);
-
-    if (foundSession.status === 'pending' || foundSession.status === 'accepted') {
-      foundSession.status = 'rejected';
-      return res.status(200).send({ status: 200, data: foundSession });
+    try {
+      const session = req.data[0][0];
+      return response.onSuccess(res, 200, '', session);
+    } catch (error) {
+      return response.onError(res, 500, error.message);
     }
-    return res.status(401).send({ status: 401, error: 'This session is already rejected' });
   }
 
   static reviewMentor(req, res) {

--- a/server/helpers/declineReq.js
+++ b/server/helpers/declineReq.js
@@ -1,0 +1,18 @@
+import execute from '../config/connectDb';
+import query from '../config/queries';
+import response from './responses';
+
+  const declineHelper = async (req, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const isSessionFound = req.data[0][0];
+    if (isSessionFound.status === 'pending' || isSessionFound.status === 'accepted') {
+      const declineSession = await execute(query[1].reject, [id]);
+      req.data = [declineSession];
+      next();
+    } else return response.onError(res, 409, 'This session is already rejected');
+  } catch (error) {
+    return response.onError(res, 500, error.message);
+  } 
+}
+export default declineHelper;

--- a/server/helpers/sessionServer.js
+++ b/server/helpers/sessionServer.js
@@ -6,10 +6,10 @@ class Session {
   static async sessionHelper (req, res, next) {
     try {
       const { mentorEmail, questions } = req.body;
-      const isMentor = await execute(query[0].isExist, [mentorEmail]);
+      const isMentor = await execute(query[0].isMentorEmail, [mentorEmail]);      
       const isSession = await execute(query[1].isSessionExist, [questions, req.payload.email]);
       if(!isMentor[0]) {
-        return response.onError(res, 404, 'User not exist');
+        return response.onError(res, 403, 'You cannot create a session with this user');
       }      
 
       if (isSession.length === 0) {

--- a/server/middleware/authentication.js
+++ b/server/middleware/authentication.js
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import users from '../helpers/userServer';
 import user from '../data/users';
 import encryptToken from '../helpers/tokenEncryption';
-import sessions from '../data/sessionsReq';
+import sessions from '../data/sessionsReq'; 
 import responses from '../helpers/responses';
 import execute from '../config/connectDb';
 import query from '../config/queries';
@@ -78,12 +78,12 @@ class Authenticate {
             req.data = [sessionFound];
             next();
           } else {
-            return res.status(403).send({ status: 403, error: 'You cannot accept or reject this request' });
+            return responses.onError(res, 403, 'You cannot accept or reject this request');
           }
-        } else return res.status(404).send({ status: 404, error: 'session request not found' });
+        } else return responses.onError(res, 404, 'Session not found');
       } else return responses.onError(res, 401, 'Unauthorized user'); 
     } catch (error) {
-      return res.status(401).send({ status: 401, error: error.message });
+      return responses.onError(res, 401, error.message);
     }
   }
 

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -7,6 +7,7 @@ import sessValidate from '../validations/sessionValidations';
 import reviewValidation from '../validations/reviewValidation';
 import userHelper from '../helpers/userServer';
 import sessionHelp from '../helpers/sessionServer';
+import decline from '../helpers/declineReq';
 
 const router = express.Router();
 
@@ -16,7 +17,7 @@ router.get('/mentors', auth.authUser,userControl.getAllMentors);
 router.get('/mentors/:mentorId', auth.authUser, userHelper.getOne, userControl.getMentor);
 router.post('/sessions', sessValidate,auth.authSession,sessionHelp.sessionHelper, sessions.create);
 router.patch('/sessions/:id/accept', auth.authAcceptRequest, sessionHelp.acceptHelper, sessions.acceptMentorship);
-router.patch('/sessions/:id/reject',auth.authAcceptRequest, sessions.declineMentorship);
+router.patch('/sessions/:id/reject',auth.authAcceptRequest, decline,sessions.declineMentorship);
 router.post('/sessions/:id/review', reviewValidation, auth.authReview, sessions.reviewMentor);
 
 export default router;

--- a/server/tests/userTests.js
+++ b/server/tests/userTests.js
@@ -6,12 +6,13 @@ import users from './helpers/usersSignup';
 import signin from './helpers/userSignin';
 import token from './helpers/tokens';
 import sessions from './helpers/sessions';
+import session from './helpers/sessions';
 
 dotenv.config();
 chai.use(chaiHttp);
 chai.should();
 
-
+let id = 0;
 
 describe('Catch any error', () => {
   it('should catch error when on a wrong route', (done) => {
@@ -278,28 +279,28 @@ describe('Session tests', () => {
         done();
       })
   });
-  it('should not be able to create mentorship request when email is invalid', (done => {
+  it('should not be able to create mentorship request when email is invalid', ((done) => {
     chai.request(app).post('/api/v2/sessions').set('x-token', token.mentee.real)
       .send(sessions[2]).end((err, res) => {
         res.should.have.status(400);
         done();
       })
   }));
-  it('should not be able to create mentorship request when questions is invalid', (done => {
+  it('should not be able to create mentorship request when questions is invalid', ((done) => {
     chai.request(app).post('/api/v2/sessions').set('x-token', token.mentee.real)
       .send(sessions[3]).end((err, res) => {
         res.should.have.status(400);
         done();
       })
   }));
-  it('should not be able to create mentorship request when token is not provided', (done => {
+  it('should not be able to create mentorship request when token is not provided', ((done) => {
     chai.request(app).post('/api/v2/sessions').set('x-token', '')
       .send(sessions[0]).end((err, res) => {
         res.should.have.status(401);
         done();
       })
   }));
-  it('should not be able to create mentorship request when token is invalid', (done => {
+  it('should not be able to create mentorship request when token is invalid', ((done) => {
     chai.request(app).post('/api/v2/sessions').set('x-token',token.mentee.fake)
       .send({
         mentorEmail: 'johndoe@gmail.com',
@@ -310,21 +311,21 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to create mentorship request when is admin', (done => {
+  it('should not be able to create mentorship request when is admin', ((done) => {
     chai.request(app).post('/api/v2/sessions').set('x-token',token.admin.real)
       .send(sessions[0]).end((err, res) => {
         res.should.have.status(403);
         done();
       })
   }));
-  it('should not be able to create mentorship request when is a mentor', (done => {
+  it('should not be able to create mentorship request when is a mentor', ((done) => {
     chai.request(app).post('/api/v2/sessions').set('x-token',token.mentor.real)
       .send(sessions[0]).end((err, res) => {
         res.should.have.status(403);
         done();
       })
   }));
-  it('should not be able to create mentorship request when user not found', (done => {
+  it('should not be able to create mentorship request when user not found', ((done) => {
     chai.request(app).post('/api/v2/sessions').set('x-token',token.mentee.fake)
       .send(sessions[0]).end((err, res) => {
         
@@ -333,7 +334,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should be able to accept mentorship request', (done => {
+  it('should be able to accept mentorship request', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token',token.mentor.real)
       .end((err, res) => {
@@ -341,15 +342,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should be able to accept mentorship request when is rejected', (done => {
-    const id = 3;
-    chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token',token.mentor.real)
-      .end((err, res) => {
-        res.should.have.status(200);
-        done();
-      })
-  }));
-  it('should not be able to accept mentorship request when token is not provided', (done => {
+  it('should not be able to accept mentorship request when token is not provided', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token', '')
       .end((err, res) => {
@@ -357,7 +350,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to accept mentorship request when token is invalid', (done => {
+  it('should not be able to accept mentorship request when token is invalid', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token',token.mentor.fake)
       .end((err, res) => {
@@ -365,7 +358,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to accept mentorship request when already accepted', (done => {
+  it('should not be able to accept mentorship request when already accepted', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token',token.mentor.real)
       .end((err, res) => {
@@ -373,7 +366,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to accept mentorship request when is not mentor', (done => {
+  it('should not be able to accept mentorship request when is not mentor', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token',token.mentee.real)
       .end((err, res) => {        
@@ -381,7 +374,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to accept mentorship request when session is not found', (done => {
+  it('should not be able to accept mentorship request when session is not found', ((done) => {
     const id = 109;
     chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token',token.mentor.real)
       .end((err, res) => {
@@ -389,7 +382,23 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should be able to decline mentorship request when is pending', (done => {
+  it('should be able to decline mentorship request when is pending', ((done) => {
+    const id = 1;
+    chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token',token.mentor.real)
+      .end((err, res) => {        
+        res.should.have.status(200);
+        done();
+      })
+  }));
+    it('should be able to accept mentorship request when is rejected', ((done) => {
+    const id = 1;
+    chai.request(app).patch(`/api/v2/sessions/${id}/accept`).set('x-token',token.mentor.real)
+      .end((err, res) => {        
+        res.should.have.status(200);
+        done();
+      })
+  }));
+  it('should be able to decline mentorship request when is accepted', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token',token.mentor.real)
       .end((err, res) => {
@@ -397,15 +406,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should be able to decline mentorship request when is accepted', (done => {
-    const id = 2;
-    chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token',token.mentor.real)
-      .end((err, res) => {
-        res.should.have.status(200);
-        done();
-      })
-  }));
-  it('should not be able to decline mentorship request when token is not provided', (done => {
+  it('should not be able to decline mentorship request when token is not provided', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token', '')
       .end((err, res) => {
@@ -413,7 +414,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to decline mentorship request when token is invalid', (done => {
+  it('should not be able to decline mentorship request when token is invalid', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token',token.mentor.fake)
       .end((err, res) => {
@@ -421,16 +422,16 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to decline mentorship request when already rejected', (done => {
-    const id = 2;
+  it('should not be able to decline mentorship request when already rejected', ((done) => {
+    const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token',token.mentor.real)
       .end((err, res) => {
-        res.should.have.status(401);
+        res.should.have.status(409);
         done();
       })
   }));
 
-  it('should not be able to decline mentorship request when is not mentor', (done => {
+  it('should not be able to decline mentorship request when is not mentor', ((done) => {
     const id = 1;
     chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token',token.mentee.real)
       .end((err, res) => {
@@ -438,7 +439,7 @@ describe('Session tests', () => {
         done();
       })
   }));
-  it('should not be able to accept mentorship request when session is not found', (done => {
+  it('should not be able to accept mentorship request when session is not found', ((done) => {
     const id = 109;
     chai.request(app).patch(`/api/v2/sessions/${id}/reject`).set('x-token',token.mentor.real)
       .end((err, res) => {
@@ -449,7 +450,7 @@ describe('Session tests', () => {
 });
 
 describe('Review Tests', () => {
-  it('should be able to review session', (done => {
+  it('should be able to review session', ((done) => {
     const id = 3;
     
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[4])
@@ -458,7 +459,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when score is less than 1', (done => {
+  it('should not be able to review session when score is less than 1', ((done) => {
     const id = 4;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[5])
       .end((err, res) => {
@@ -466,7 +467,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when score is greater than 5', (done => {
+  it('should not be able to review session when score is greater than 5', ((done) => {
     const id = 3;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[6])
       .end((err, res) => {
@@ -474,7 +475,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when remark is empty', (done => {
+  it('should not be able to review session when remark is empty', ((done) => {
     const id = 3;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[8])
       .end((err, res) => {
@@ -482,7 +483,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when remark is invalid', (done => {
+  it('should not be able to review session when remark is invalid', ((done) => {
     const id = 3;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[9])
       .end((err, res) => {
@@ -490,7 +491,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when token not provided', (done => {
+  it('should not be able to review session when token not provided', ((done) => {
     const id = 3;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token', '').send(sessions[4])
       .end((err, res) => {
@@ -498,7 +499,7 @@ describe('Review Tests', () => {
         done();
       });
   }));
-  it('should not be able to review session when token is invalid', (done => {
+  it('should not be able to review session when token is invalid', ((done) => {
     const id = 3;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.mentee.fake).send(sessions[4])
       .end((err, res) => {
@@ -506,7 +507,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when session not found', (done => {
+  it('should not be able to review session when session not found', ((done) => {
     const id = 19;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[4])
       .end((err, res) => {
@@ -514,7 +515,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when session is already reviewed', (done => {
+  it('should not be able to review session when session is already reviewed', ((done) => {
     const id = 3;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[4])
       .end((err, res) => {
@@ -522,7 +523,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when token is not from the user who created the session', (done => {
+  it('should not be able to review session when token is not from the user who created the session', ((done) => {
     const id = 3;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.admin.real).send(sessions[4])
       .end((err, res) => {
@@ -530,7 +531,7 @@ describe('Review Tests', () => {
         done();
       })
   }));
-  it('should not be able to review session when the session is not accepted yet', (done => {
+  it('should not be able to review session when the session is not accepted yet', ((done) => {
     const id = 1;
     chai.request(app).post(`/api/v2/sessions/${id}/review`).set('x-token',token.review.real).send(sessions[4])
       .end((err, res) => {


### PR DESCRIPTION
#### What does this PR do?
It creates an endpoint for a mentor to decline a session request
#### Description of Task to be completed?
- create endpoint where a mentor can decline a session request
- add function to handle all conditions from the controller
- refactor authentication codes
#### How should this be manually tested?
- Clone this repository to your local PC
- Open the cloned folder and run the server by typing `npm start`
- In POSTMAN create a PATCH method on this route `/api/v2/sessions/:id(id of the session)/reject` and ensure the token provided is from the mentor against whom the session was created and it will respond with a 200 HTTP status code along with the updated data
- otherwise, it will respond with a relevant error message
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[#168360951](https://www.pivotaltracker.com/story/show/168360951)
#### Screenshots (if appropriate)
**On success**
![image](https://user-images.githubusercontent.com/51836855/64825365-dac6e780-d571-11e9-9cbb-ec026234d717.png)

**On error**
![image](https://user-images.githubusercontent.com/51836855/64825376-e61a1300-d571-11e9-9ef4-474f5e3fbe26.png)

#### Questions:
- N/A